### PR TITLE
chore: specify version to 29.4.0 in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [metadata]
 name = nova
+version = 29.4.0
 summary = Cloud computing fabric controller
 description_file =
     README.rst


### PR DESCRIPTION
nova 이미지가 빌드될 때 pbr을 통해 버전값을 활용하는데, pbr은 기본적으로 git tag값을 사용하고 있습니다. 따라서 별도의 tag로 운영되는 kcloud-nova는 이 값을 nova:stable/2024.1의 tag값인 29.4.0으로 강제적으로 설정합니다.

관련 이슈: #11 