### PR TITLE
Add AcceleratorWeigher: Placement-based accelerator-aware scheduler weigher

### DIFF
--- a/nova/conf/__init__.py
+++ b/nova/conf/__init__.py
@@ -19,6 +19,7 @@
 
 from oslo_config import cfg
 
+from nova.conf import accelerator_weigher
 from nova.conf import api
 from nova.conf import availability_zone
 from nova.conf import base
@@ -66,6 +67,7 @@ from nova.conf import zvm
 
 CONF = cfg.CONF
 
+accelerator_weigher.register_opts(CONF)
 api.register_opts(CONF)
 availability_zone.register_opts(CONF)
 base.register_opts(CONF)

--- a/nova/conf/accelerator_weigher.py
+++ b/nova/conf/accelerator_weigher.py
@@ -90,6 +90,43 @@ Related options:
 
 * ``[filter_scheduler] weight_classes``
 """),
+    cfg.IntOpt(
+        "usage_cache_seconds",
+        default=10,
+        min=0,
+        help="""
+TTL in seconds for cached resource provider usage data.
+
+The AcceleratorWeigher fetches usage data from Placement for each child
+resource provider. This option controls how long fetched usage data is
+reused across scheduling passes before being refreshed.
+
+Set to 0 to disable cross-pass caching (usage is still cached within
+a single scheduling pass via the per-pass cache).
+
+Possible values:
+
+* A non-negative integer, where the integer corresponds to cache TTL
+  in seconds.
+"""),
+    cfg.IntOpt(
+        "max_concurrent_usage_requests",
+        default=8,
+        min=1,
+        help="""
+Maximum number of concurrent HTTP requests for fetching RP usages.
+
+The AcceleratorWeigher fetches usage data for each child resource provider
+under a compute host's root RP. This option controls how many of these
+requests run in parallel using a thread pool.
+
+Higher values reduce wall-clock time for hosts with many child RPs
+(e.g., multiple GPUs/FPGAs) but increase concurrent load on Placement.
+
+Possible values:
+
+* A positive integer.
+"""),
     cfg.BoolOpt(
         "trace",
         default=False,

--- a/nova/conf/accelerator_weigher.py
+++ b/nova/conf/accelerator_weigher.py
@@ -54,6 +54,9 @@ Related options:
         help="""
 Scoring policy for accelerator weighing.
 
+This is the default policy. It can be overridden per request via the
+flavor extra_spec ``accelerator_weigher:policy``.
+
 Possible values:
 
 * ``sum-fit``: Score is the sum of group slacks across all request groups.

--- a/nova/conf/accelerator_weigher.py
+++ b/nova/conf/accelerator_weigher.py
@@ -1,0 +1,118 @@
+# Copyright 2024 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from oslo_config import cfg
+
+accelerator_weigher_group = cfg.OptGroup(
+    name="accelerator_weigher",
+    title="Accelerator Weigher configuration",
+    help="""
+Configuration options for the AcceleratorWeigher scheduler weigher.
+
+The AcceleratorWeigher scores compute hosts based on accelerator resource
+availability (GPU, FPGA, etc.) by querying the Placement API. It uses a
+group-based RC+traits calculation with configurable scoring policies.
+""")
+
+accelerator_weigher_opts = [
+    cfg.StrOpt(
+        "rc_pattern",
+        default=r"(?i)^(CUSTOM_)?(FPGA|PGPU|VGPU|QAT|NIC|SSD|AICHIP)$",
+        help="""
+Regex to identify accelerator resource classes included in scoring.
+
+This pattern is matched against resource class names from Placement to
+determine which resources are considered accelerators for weighing purposes.
+
+Possible values:
+
+* A valid Python regular expression string.
+
+Default matches: FPGA, PGPU, VGPU, CUSTOM_QAT, CUSTOM_NIC, CUSTOM_SSD,
+CUSTOM_AICHIP (case-insensitive).
+
+Related options:
+
+* ``[filter_scheduler] weight_classes``
+"""),
+    cfg.StrOpt(
+        "policy",
+        default="sum-fit",
+        choices=["sum-fit", "product-fit"],
+        help="""
+Scoring policy for accelerator weighing.
+
+Possible values:
+
+* ``sum-fit``: Score is the sum of group slacks across all request groups.
+  Hosts with more total free accelerator capacity score higher.
+* ``product-fit``: Score is the product of (group_slack + epsilon) across
+  groups. Rewards hosts that have balanced capacity across all requested
+  resource types.
+
+Related options:
+
+* ``[filter_scheduler] weight_classes``
+"""),
+    cfg.FloatOpt(
+        "accelerator_weight_multiplier",
+        default=1.0,
+        help="""
+Multiplier applied to the final accelerator score.
+
+This option determines how the accelerator weigher score influences host
+selection relative to other weighers. A positive value prefers hosts with
+more free accelerator resources (spreading). A negative value prefers hosts
+with fewer free resources (stacking). Zero disables the weigher.
+
+The value of this configuration option can be overridden per host aggregate
+by setting the aggregate metadata key with the same name
+(``accelerator_weight_multiplier``).
+
+Possible values:
+
+* An integer or float value, where the value corresponds to the multiplier
+  ratio for this weigher.
+
+Related options:
+
+* ``[filter_scheduler] weight_classes``
+"""),
+    cfg.BoolOpt(
+        "trace",
+        default=False,
+        help="""
+Emit verbose DEBUG logs for detailed flow tracing.
+
+When enabled, the AcceleratorWeigher logs detailed information about each
+step of the weighing process, including HTTP calls, provider tree traversal,
+trait matching, and scoring calculations.
+
+Possible values:
+
+* A boolean value.
+"""),
+]
+
+
+def register_opts(conf):
+    conf.register_group(accelerator_weigher_group)
+    conf.register_opts(accelerator_weigher_opts, group=accelerator_weigher_group)
+
+
+def list_opts():
+    return {
+        accelerator_weigher_group: accelerator_weigher_opts,
+    }

--- a/nova/scheduler/weights/accelerator.py
+++ b/nova/scheduler/weights/accelerator.py
@@ -26,6 +26,7 @@ from oslo_log import log as logging
 import nova.conf
 from nova import context
 from nova.compute import provider_tree
+from nova.scheduler import utils
 from nova.scheduler import weights
 from nova.scheduler.client import report as placement_report
 
@@ -336,7 +337,14 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
         return super().weigh_objects(weighed_obj_list, weight_properties)
 
     def weight_multiplier(self, host_state):
-        return CONF.accelerator_weigher.accelerator_weight_multiplier
+        """Override the weight multiplier.
+
+        Reads ``accelerator_weight_multiplier`` from aggregate metadata
+        to allow per-aggregate override, falling back to the config value.
+        """
+        return utils.get_weight_multiplier(
+            host_state, 'accelerator_weight_multiplier',
+            CONF.accelerator_weigher.accelerator_weight_multiplier)
 
     def _weigh_object(self, host_state, weight_properties):
         """Score host per policy.

--- a/nova/scheduler/weights/accelerator.py
+++ b/nova/scheduler/weights/accelerator.py
@@ -36,6 +36,9 @@ CONF = nova.conf.CONF
 
 EPS = 1e-6
 UNMET_FLOOR = -1e6
+VALID_POLICIES = frozenset({
+    "sum-fit", "product-fit",
+})
 
 _rc_regex_cache = None
 _rc_regex_pattern = None
@@ -403,21 +406,41 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
 
         return ptree, usages_dict
 
-    def _apply_policy(self, group_slacks):
-        """Compute final score from group slacks using configured policy.
+    def _get_policy(self, weight_properties):
+        """Resolve scoring policy: flavor extra_spec override or config default.
+
+        Flavor extra_spec key: ``accelerator_weigher:policy``
+        """
+        flavor = getattr(weight_properties, 'flavor', None)
+        if flavor:
+            extra_specs = getattr(flavor, 'extra_specs', None) or {}
+            override = extra_specs.get('accelerator_weigher:policy')
+            if override and override in VALID_POLICIES:
+                _trace("Policy override from flavor extra_spec: %s", override)
+                return override
+        return CONF.accelerator_weigher.policy
+
+    def _apply_policy(self, group_slacks, policy=None):
+        """Compute final score from group slacks using the given policy.
+
+        Supported policies: sum-fit, product-fit.
 
         Returns: float score, or UNMET_FLOOR if any group is unmet.
         """
+        if policy is None:
+            policy = CONF.accelerator_weigher.policy
+
         if any(gs == UNMET_FLOOR for gs in group_slacks):
             return UNMET_FLOOR
 
-        policy = CONF.accelerator_weigher.policy
         if policy == "sum-fit":
             score = sum(group_slacks)
-        else:  # product-fit
+        elif policy == "product-fit":
             score = 1.0
             for gs in group_slacks:
                 score *= (gs + EPS)
+        else:
+            score = sum(group_slacks)  # fallback
 
         _trace("policy=%s slacks=%s -> score=%.6f",
                policy, group_slacks, score)
@@ -467,7 +490,10 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
             LOG.debug("No root RP for host=%s; returning 0", host_name)
             return 0.0
 
-        # 2. Extract accelerator request groups
+        # 2. Resolve policy (flavor extra_spec override or config default)
+        policy = self._get_policy(weight_properties)
+
+        # 3. Extract accelerator request groups
         rc_regex = _get_rc_regex()
         groups = _extract_accel_groups(weight_properties, rc_regex, stats=stats)
         if not groups:
@@ -475,7 +501,7 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
                       host_name)
             return 0.0
 
-        # 3. Fetch ProviderTree + usages
+        # 4. Fetch ProviderTree + usages
         ptree, usages_dict = self._fetch_data(root_uuid, client, stats)
         if not ptree:
             LOG.debug("Failed to build ProviderTree for host=%s; returning 0",
@@ -489,7 +515,7 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
             LOG.debug("Root %s not found in ProviderTree", root_uuid)
             return 0.0
 
-        # 4. Compute per-group slack
+        # 5. Compute per-group slacks and apply the scoring policy
         group_slacks = []
         for idx, (accel_resources, req_traits) in enumerate(groups):
             _trace("Processing group[%d] on host=%s", idx, host_name)
@@ -498,14 +524,12 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
                 usages_dict, stats=stats, provider_uuids=provider_uuids)
             group_slacks.append(gs)
             _trace("group[%d] -> slack=%.3f", idx, gs)
-
-        # 5. Apply scoring policy
-        score = self._apply_policy(group_slacks)
+        score = self._apply_policy(group_slacks, policy=policy)
 
         LOG.debug(
             "AcceleratorWeigher host=%s root_rp=%s policy=%s "
             "groups=%d slacks=%s score=%.6f",
-            host_name, root_uuid, CONF.accelerator_weigher.policy,
+            host_name, root_uuid, policy,
             len(group_slacks), group_slacks, score)
 
         self._build_stats(

--- a/nova/scheduler/weights/accelerator.py
+++ b/nova/scheduler/weights/accelerator.py
@@ -17,8 +17,10 @@ Tracing:
 """
 
 import re
+import threading
 import time
 import pprint
+from concurrent import futures
 from typing import Dict, List, Optional, Tuple, Set
 from urllib.parse import quote
 
@@ -100,9 +102,10 @@ def _lookup_root_rp_uuid(client: placement_report.SchedulerReportClient, host_st
     return root_uuid
 
 
-def _get_provider_tree_and_usages(client: placement_report.SchedulerReportClient, root_uuid: str, stats: Dict) -> Tuple[Optional[provider_tree.ProviderTree], Dict[str, Dict[str, float]]]:
+def _get_provider_tree_and_usages(client: placement_report.SchedulerReportClient, root_uuid: str, stats: Dict, skip_usages: bool = False) -> Tuple[Optional[provider_tree.ProviderTree], Dict[str, Dict[str, float]]]:
     """Get ProviderTree using get_provider_tree_and_ensure_root() and collect usages.
 
+    :param skip_usages: If True, skip fetching usage data (caller has cached usages).
     Returns:
         Tuple of (ProviderTree, usages_dict) where usages_dict maps rp_uuid -> {rc: usage}
     """
@@ -133,23 +136,40 @@ def _get_provider_tree_and_usages(client: placement_report.SchedulerReportClient
         stats["errors"].append("root-not-in-tree")
         return None, {}
 
-    # Collect usage information (not included in ProviderTree)
-    usages_dict = {}  # rp_uuid -> {rc: usage}
-    for rp_uuid in provider_uuids:
-        if rp_uuid == root_uuid:
-            continue
+    if skip_usages:
+        _trace("Skipping usage fetch (caller has cached usages)")
+        return ptree, {}
 
+    # Collect usage information (not included in ProviderTree).
+    # Fetch concurrently to reduce wall-clock time for hosts with many child RPs.
+    child_uuids = [u for u in provider_uuids if u != root_uuid]
+    max_workers = min(
+        CONF.accelerator_weigher.max_concurrent_usage_requests,
+        len(child_uuids) or 1)
+    stats_lock = threading.Lock()
+
+    def _fetch_usage(rp_uuid):
         t0 = time.time()
-        usage_url = f"/resource_providers/{rp_uuid}/usages"
-        _trace("HTTP GET %s", usage_url)
-        usage_resp = client.get(usage_url)
+        url = f"/resource_providers/{rp_uuid}/usages"
+        _trace("HTTP GET %s", url)
+        resp = client.get(url)
         dt = (time.time() - t0) * 1000.0
-        stats["http_calls"] = stats.get("http_calls", 0) + 1
-        stats["http_times_ms"] = stats.get("http_times_ms", 0.0) + dt
+        with stats_lock:
+            stats["http_calls"] = stats.get("http_calls", 0) + 1
+            stats["http_times_ms"] = stats.get("http_times_ms", 0.0) + dt
+        if resp.status_code == 200:
+            return rp_uuid, (resp.json() or {}).get("usages", {}) or {}
+        return rp_uuid, {}
 
-        if usage_resp.status_code == 200:
-            usages = (usage_resp.json() or {}).get("usages", {}) or {}
-            usages_dict[rp_uuid] = usages
+    usages_dict = {}
+    _trace("Fetching usages for %d child RPs (max_workers=%d)", len(child_uuids), max_workers)
+    t_usage_start = time.time()
+    with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+        for rp_uuid, usages in executor.map(_fetch_usage, child_uuids):
+            if usages:
+                usages_dict[rp_uuid] = usages
+    stats["usage_fetch_ms"] = (time.time() - t_usage_start) * 1000.0
+    _trace("Usage fetch complete: %d RPs in %.1f ms", len(usages_dict), stats["usage_fetch_ms"])
 
     return ptree, usages_dict
 
@@ -330,6 +350,9 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
         # Per-scheduling-pass cache: {root_uuid: (ptree, usages_dict)}
         # Cleared at the start of each weigh_objects() call to avoid stale data.
         self._pass_cache = {}
+        # Cross-pass TTL cache for usage data: {root_uuid: (timestamp, usages_dict)}
+        # Persists across weigh_objects() calls; entries expire after usage_cache_seconds.
+        self._usage_cache = {}
 
     def weigh_objects(self, weighed_obj_list, weight_properties):
         """Clear per-pass cache before weighing a new set of hosts."""
@@ -397,13 +420,28 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
         # Use per-pass cache to avoid redundant Placement calls for the same root RP.
         if root_uuid in self._pass_cache:
             ptree, usages_dict = self._pass_cache[root_uuid]
-            stats["cache_hit"] = True
-            _trace("Cache hit for root_uuid=%s (skipped ProviderTree + usage HTTP calls)", root_uuid)
+            stats["cache_hit"] = "pass"
+            _trace("Pass-cache hit for root_uuid=%s", root_uuid)
         else:
-            ptree, usages_dict = _get_provider_tree_and_usages(client, root_uuid, stats=stats)
+            # Check TTL cache for usage data to avoid re-fetching across passes.
+            ttl = CONF.accelerator_weigher.usage_cache_seconds
+            cached_entry = self._usage_cache.get(root_uuid)
+            if cached_entry and ttl > 0 and (time.time() - cached_entry[0]) < ttl:
+                cached_usages = cached_entry[1]
+                stats["cache_hit"] = "ttl"
+                _trace("TTL-cache hit for root_uuid=%s (age=%.1fs, ttl=%ds)",
+                       root_uuid, time.time() - cached_entry[0], ttl)
+                # Still need a fresh ProviderTree (inventories/traits may change)
+                ptree, _ = _get_provider_tree_and_usages(client, root_uuid, stats=stats, skip_usages=True)
+                usages_dict = cached_usages
+            else:
+                ptree, usages_dict = _get_provider_tree_and_usages(client, root_uuid, stats=stats)
+                stats["cache_hit"] = False
+                # Update TTL cache
+                if ptree and ttl > 0:
+                    self._usage_cache[root_uuid] = (time.time(), usages_dict)
             if ptree:
                 self._pass_cache[root_uuid] = (ptree, usages_dict)
-            stats["cache_hit"] = False
         if not ptree:
             LOG.debug("Failed to build ProviderTree for host=%s; returning 0", host_name)
             _trace("==== weigh_object END (no ProviderTree) host=%r ====", host_name)

--- a/nova/scheduler/weights/accelerator.py
+++ b/nova/scheduler/weights/accelerator.py
@@ -2,18 +2,16 @@
 """
 Accelerator Weigher (group-based with RC+traits; sum-fit & product-fit policies)
 -----------------------------------------------------------------------------------
-- Per RequestGroup calculation using Placement data.
-- "RC+traits" basis: an RP must both hold the RC inventory AND satisfy traits.
-- Policies:
-    sum-fit      : sum of group_slacks over groups
-                   -> score = sum(group_slacks)
-    product-fit  : product of (group_slack + epsilon) over groups
-                   -> score = product(group_slacks + epsilon) with epsilon to avoid 0
-- Placement access via Nova's SchedulerReportClient singleton.
+Scores compute hosts based on accelerator resource availability by querying the
+Placement API.  Per RequestGroup calculation using RC+traits: an RP must both
+hold the RC inventory AND satisfy the required traits.
+
+Policies:
+    sum-fit      : score = sum(group_slacks)
+    product-fit  : score = product(group_slack + epsilon)  (epsilon avoids 0)
 
 Tracing:
-- Set [accelerator_weigher] trace = true to emit very detailed DEBUG logs.
-- A per-call 'stats' dict is collected and dumped at the end for quick overview.
+    Set [accelerator_weigher] trace = true for detailed DEBUG logs.
 """
 
 import re
@@ -52,6 +50,7 @@ def _get_rc_regex() -> re.Pattern:
         _rc_regex_pattern = pattern
     return _rc_regex_cache
 
+
 # ------------------------------ trace helper ------------------------------
 
 def _trace(fmt: str, *args):
@@ -60,7 +59,7 @@ def _trace(fmt: str, *args):
         LOG.debug("[ACCEL TRACE] " + fmt, *args)
 
 
-# ------------------------------ Placement client helpers ------------------------------
+# ------------------------------ Placement helpers -------------------------
 
 def _get_client() -> placement_report.SchedulerReportClient:
     """Return the global singleton SchedulerReportClient instance."""
@@ -69,12 +68,16 @@ def _get_client() -> placement_report.SchedulerReportClient:
     return client
 
 
-
-
-def _lookup_root_rp_uuid(client: placement_report.SchedulerReportClient, host_state, stats: Dict) -> Optional[str]:
+def _lookup_root_rp_uuid(
+    client: placement_report.SchedulerReportClient,
+    host_state,
+    stats: Dict,
+) -> Optional[str]:
     """Resolve compute RP UUID by hypervisor name using client.get()."""
-    name = getattr(host_state, "hypervisor_hostname", None) or getattr(host_state, "host", None)
-    _trace("Lookup root RP for host=%r hypervisor_hostname=%r", getattr(host_state, "host", None), name)
+    name = (getattr(host_state, "hypervisor_hostname", None)
+            or getattr(host_state, "host", None))
+    _trace("Lookup root RP for host=%r hypervisor_hostname=%r",
+           getattr(host_state, "host", None), name)
     if not name:
         _trace("Host has no name; cannot lookup root RP")
         stats["errors"].append("no-hostname")
@@ -85,48 +88,51 @@ def _lookup_root_rp_uuid(client: placement_report.SchedulerReportClient, host_st
     _trace("HTTP GET %s", url)
     resp = client.get(url)
     dt = (time.time() - t0) * 1000.0
-    code = getattr(resp, "status_code", None)
-    _trace("HTTP RESP %s -> %s (%.1f ms)", url, code, dt)
+    _trace("HTTP RESP %s -> %s (%.1f ms)", url,
+           getattr(resp, "status_code", None), dt)
     stats["http_calls"] = stats.get("http_calls", 0) + 1
     stats["http_times_ms"] = stats.get("http_times_ms", 0.0) + dt
 
     if resp.status_code != 200:
-        LOG.debug("RP lookup failed for %s: %s %s", name, resp.status_code, getattr(resp, "text", "?"))
+        LOG.debug("RP lookup failed for %s: %s %s",
+                  name, resp.status_code, getattr(resp, "text", "?"))
         stats["errors"].append(f"rp-lookup-{resp.status_code}")
         return None
+
     rps = (resp.json() or {}).get("resource_providers", []) or []
-    root_uuid = rps[0].get("uuid") if rps else None
-    _trace("Root RP uuid for %s -> %s", name, root_uuid)
     if not rps:
         stats["errors"].append("rp-lookup-empty")
+        return None
+    root_uuid = rps[0].get("uuid")
+    _trace("Root RP uuid for %s -> %s", name, root_uuid)
     return root_uuid
 
 
-def _get_provider_tree_and_usages(client: placement_report.SchedulerReportClient, root_uuid: str, stats: Dict, skip_usages: bool = False) -> Tuple[Optional[provider_tree.ProviderTree], Dict[str, Dict[str, float]]]:
-    """Get ProviderTree using get_provider_tree_and_ensure_root() and collect usages.
+def _get_provider_tree_and_usages(
+    client: placement_report.SchedulerReportClient,
+    root_uuid: str,
+    stats: Dict,
+    skip_usages: bool = False,
+) -> Tuple[Optional[provider_tree.ProviderTree], Dict[str, Dict[str, float]]]:
+    """Get ProviderTree and optionally collect usages from Placement.
 
-    :param skip_usages: If True, skip fetching usage data (caller has cached usages).
-    Returns:
-        Tuple of (ProviderTree, usages_dict) where usages_dict maps rp_uuid -> {rc: usage}
+    :param skip_usages: If True, return empty usages (caller has cached data).
+    :returns: (ProviderTree, usages_dict) where usages_dict maps
+              rp_uuid -> {rc: usage}.
     """
-    _trace("Get ProviderTree for root=%s using get_provider_tree_and_ensure_root", root_uuid)
-
-    # Create a minimal context for the API call
+    _trace("Get ProviderTree for root=%s", root_uuid)
     ctx = context.get_context()
 
-    # Get ProviderTree with all inventories and traits populated
     t0 = time.time()
     try:
         ptree = client.get_provider_tree_and_ensure_root(ctx, root_uuid)
-        dt = (time.time() - t0) * 1000.0
-        stats["tree_call_ms"] = dt
-        _trace("get_provider_tree_and_ensure_root returned ProviderTree (%.1f ms)", dt)
+        stats["tree_call_ms"] = (time.time() - t0) * 1000.0
+        _trace("ProviderTree returned (%.1f ms)", stats["tree_call_ms"])
     except Exception as e:
         LOG.debug("Failed to get ProviderTree: %s", e, exc_info=True)
         stats["errors"].append(f"get-tree-{type(e).__name__}")
         return None, {}
 
-    # Get provider UUIDs in tree
     try:
         provider_uuids = ptree.get_provider_uuids_in_tree(root_uuid)
         stats["providers_total"] = len(provider_uuids)
@@ -140,12 +146,14 @@ def _get_provider_tree_and_usages(client: placement_report.SchedulerReportClient
         _trace("Skipping usage fetch (caller has cached usages)")
         return ptree, {}
 
-    # Collect usage information (not included in ProviderTree).
-    # Fetch concurrently to reduce wall-clock time for hosts with many child RPs.
+    # Fetch usages concurrently for all child RPs.
     child_uuids = [u for u in provider_uuids if u != root_uuid]
+    if not child_uuids:
+        return ptree, {}
+
     max_workers = min(
         CONF.accelerator_weigher.max_concurrent_usage_requests,
-        len(child_uuids) or 1)
+        len(child_uuids))
     stats_lock = threading.Lock()
 
     def _fetch_usage(rp_uuid):
@@ -161,70 +169,39 @@ def _get_provider_tree_and_usages(client: placement_report.SchedulerReportClient
             return rp_uuid, (resp.json() or {}).get("usages", {}) or {}
         return rp_uuid, {}
 
+    _trace("Fetching usages for %d child RPs (max_workers=%d)",
+           len(child_uuids), max_workers)
+    t_usage = time.time()
     usages_dict = {}
-    _trace("Fetching usages for %d child RPs (max_workers=%d)", len(child_uuids), max_workers)
-    t_usage_start = time.time()
     with futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
         for rp_uuid, usages in executor.map(_fetch_usage, child_uuids):
             if usages:
                 usages_dict[rp_uuid] = usages
-    stats["usage_fetch_ms"] = (time.time() - t_usage_start) * 1000.0
-    _trace("Usage fetch complete: %d RPs in %.1f ms", len(usages_dict), stats["usage_fetch_ms"])
+    stats["usage_fetch_ms"] = (time.time() - t_usage) * 1000.0
+    _trace("Usage fetch complete: %d RPs in %.1f ms",
+           len(usages_dict), stats["usage_fetch_ms"])
 
     return ptree, usages_dict
 
 
-def _get_free_for_rc_from_tree(ptree: provider_tree.ProviderTree, rp_uuid: str, rc_name: str, usages_dict: Dict[str, Dict[str, float]], stats: Dict) -> float:
-    """Compute free units for RC on RP using ProviderTree data: max(total - reserved - used, 0)."""
-    _trace("Compute free for RP=%s RC=%s", rp_uuid, rc_name)
+# ------------------------------ Request parsing ---------------------------
 
-    try:
-        prov_data = ptree.data(rp_uuid)
-    except ValueError:
-        _trace("RP=%s not found in tree", rp_uuid)
-        stats["rc_miss"] = stats.get("rc_miss", 0) + 1
-        return 0.0
-
-    # Get inventory from ProviderTree
-    inventory = prov_data.inventory.get(rc_name)
-    if not inventory:
-        _trace("RP=%s has no inventory for RC=%s", rp_uuid, rc_name)
-        stats["rc_miss"] = stats.get("rc_miss", 0) + 1
-        return 0.0
-
-    total = float(inventory.get("total", 0))
-    reserved = float(inventory.get("reserved", 0))
-    _trace("Inventory RP=%s RC=%s total=%.3f reserved=%.3f", rp_uuid, rc_name, total, reserved)
-
-    # Get usage from usages_dict
-    used = float(usages_dict.get(rp_uuid, {}).get(rc_name, 0))
-    _trace("Usage RP=%s RC=%s used=%.3f", rp_uuid, rc_name, used)
-
-    free = total - reserved - used
-    free = free if free > 0 else 0.0
-    _trace("Free RP=%s RC=%s -> %.3f", rp_uuid, rc_name, free)
-    if free > 0:
-        stats["free_contribs"] = stats.get("free_contribs", 0) + 1
-    return free
-
-
-# ------------------------------ Request parsing ------------------------------
-
-def _extract_accel_groups(weight_properties, rc_regex: re.Pattern, stats: Dict) -> List[Tuple[Dict[str, int], Set[str]]]:
+def _extract_accel_groups(
+    weight_properties,
+    rc_regex: re.Pattern,
+    stats: Dict,
+) -> List[Tuple[Dict[str, int], Set[str]]]:
     """Extract accelerator-related request groups from RequestSpec.
 
-    weight_properties is a RequestSpec object with requested_resources field.
-    Returns: [(resources{rc:amount}, required_traits_set), ...]
+    Returns: [(resources{rc: amount}, required_traits_set), ...]
     """
     groups_out: List[Tuple[Dict[str, int], Set[str]]] = []
 
-    # weight_properties is already a RequestSpec object
     groups = getattr(weight_properties, "requested_resources", None) or []
     stats["groups_seen"] = len(groups)
     _trace("Extract groups: found %d request groups", len(groups))
 
     for idx, g in enumerate(groups):
-        # RequestGroup has 'resources' (dict) and 'required_traits' (set) fields
         resources = getattr(g, "resources", None) or {}
         accel_resources = {}
         for rc, amount in resources.items():
@@ -232,26 +209,29 @@ def _extract_accel_groups(weight_properties, rc_regex: re.Pattern, stats: Dict) 
                 try:
                     accel_resources[rc] = int(amount)
                 except (ValueError, TypeError):
-                    _trace("Group[%d] RC=%s invalid amount=%r; skipping", idx, rc, amount)
-                    stats["invalid_amounts"] = stats.get("invalid_amounts", 0) + 1
+                    _trace("Group[%d] RC=%s invalid amount=%r; skipping",
+                           idx, rc, amount)
+                    stats["invalid_amounts"] = (
+                        stats.get("invalid_amounts", 0) + 1)
 
-        # required_traits is already a set in RequestGroup
         req_traits = getattr(g, "required_traits", None) or set()
         if isinstance(req_traits, list):
             req_traits = set(req_traits)
 
         if accel_resources:
             groups_out.append((accel_resources, req_traits))
-            _trace("Group[%d] accel_resources=%s required_traits=%s", idx, accel_resources, sorted(req_traits))
+            _trace("Group[%d] accel_resources=%s required_traits=%s",
+                   idx, accel_resources, sorted(req_traits))
         else:
             _trace("Group[%d] skipped (no accel RC)", idx)
-            stats["groups_skipped_no_accel"] = stats.get("groups_skipped_no_accel", 0) + 1
+            stats["groups_skipped_no_accel"] = (
+                stats.get("groups_skipped_no_accel", 0) + 1)
 
     stats["groups_accel"] = len(groups_out)
     return groups_out
 
 
-# ------------------------------ RC+traits computations ------------------------------
+# ------------------------------ RC+traits computation ---------------------
 
 def _sum_free_for_rc_with_traits(
     ptree: provider_tree.ProviderTree,
@@ -262,11 +242,10 @@ def _sum_free_for_rc_with_traits(
     stats: Dict,
     provider_uuids: Optional[List[str]] = None,
 ) -> float:
-    """Sum free units for (RC + required_traits) across child RPs using ProviderTree."""
-    _trace("Sum free across tree: RC=%s required_traits=%s", rc_name, sorted(required_traits))
+    """Sum free units for (RC + required_traits) across child RPs."""
+    _trace("Sum free: RC=%s traits=%s", rc_name, sorted(required_traits))
     total_free = 0.0
 
-    # Reuse pre-fetched provider UUIDs if available
     if provider_uuids is None:
         try:
             provider_uuids = ptree.get_provider_uuids_in_tree(root_uuid)
@@ -275,8 +254,8 @@ def _sum_free_for_rc_with_traits(
             stats["errors"].append("root-not-in-tree")
             return 0.0
 
-    stats["providers_iterated"] = stats.get("providers_iterated", 0) + len(provider_uuids)
-    _trace("Traversing %d providers under root=%s", len(provider_uuids), root_uuid)
+    stats["providers_iterated"] = (
+        stats.get("providers_iterated", 0) + len(provider_uuids))
 
     for rp_uuid in provider_uuids:
         if rp_uuid == root_uuid:
@@ -285,31 +264,35 @@ def _sum_free_for_rc_with_traits(
         try:
             prov_data = ptree.data(rp_uuid)
         except ValueError:
-            _trace("Skip RP=%s (not found in tree)", rp_uuid)
             continue
 
-        # 1) Check if RC inventory exists
-        if rc_name not in prov_data.inventory:
-            _trace("Skip RP=%s (no RC=%s)", rp_uuid, rc_name)
-            stats["rps_skipped_no_rc"] = stats.get("rps_skipped_no_rc", 0) + 1
+        # Skip RPs without the requested RC
+        inv = prov_data.inventory.get(rc_name)
+        if not inv:
+            stats["rps_skipped_no_rc"] = (
+                stats.get("rps_skipped_no_rc", 0) + 1)
             continue
 
-        # 2) Traits must satisfy all required traits
+        # Skip RPs missing required traits
         if required_traits and not required_traits.issubset(prov_data.traits):
-            _trace("Skip RP=%s (traits missing) need=%s have=%s", rp_uuid, sorted(required_traits), sorted(prov_data.traits))
-            stats["rps_skipped_traits"] = stats.get("rps_skipped_traits", 0) + 1
+            stats["rps_skipped_traits"] = (
+                stats.get("rps_skipped_traits", 0) + 1)
             continue
 
-        # 3) Free contribution
-        free = _get_free_for_rc_from_tree(ptree, rp_uuid, rc_name, usages_dict, stats=stats)
+        # Compute free = total - reserved - used (floor at 0)
+        total = float(inv.get("total", 0))
+        reserved = float(inv.get("reserved", 0))
+        used = float(usages_dict.get(rp_uuid, {}).get(rc_name, 0))
+        free = max(total - reserved - used, 0.0)
+
         if free > 0:
             total_free += free
-            _trace("Accum free RC=%s RP=%s +%.3f -> total=%.3f", rc_name, rp_uuid, free, total_free)
-            stats["free_sum_updates"] = stats.get("free_sum_updates", 0) + 1
-        else:
-            stats["free_nonpos"] = stats.get("free_nonpos", 0) + 1
+            _trace("RP=%s RC=%s free=%.3f (total=%.0f reserved=%.0f "
+                   "used=%.0f) running_total=%.3f",
+                   rp_uuid, rc_name, free, total, reserved, used, total_free)
+            stats["free_contribs"] = stats.get("free_contribs", 0) + 1
 
-    _trace("Total free for RC=%s with traits=%s -> %.3f", rc_name, sorted(required_traits), total_free)
+    _trace("Total free for RC=%s -> %.3f", rc_name, total_free)
     return total_free
 
 
@@ -322,37 +305,40 @@ def _group_slack(
     stats: Dict,
     provider_uuids: Optional[List[str]] = None,
 ) -> float:
-    """Compute group slack: sum over RC of (total_free_rc - required_rc)."""
-    _trace("Compute group_slack for resources=%s traits=%s", accel_resources, sorted(required_traits))
+    """Compute group slack: sum of (free_rc - required_rc) over all RCs."""
+    _trace("group_slack: resources=%s traits=%s",
+           accel_resources, sorted(required_traits))
+
+    if not accel_resources:
+        _trace("No RCs in group -> UNMET_FLOOR")
+        return UNMET_FLOOR
+
     slacks: List[float] = []
     for rc, amount in accel_resources.items():
-        free_total = _sum_free_for_rc_with_traits(ptree, root_uuid, rc, required_traits, usages_dict, stats=stats, provider_uuids=provider_uuids)
+        free_total = _sum_free_for_rc_with_traits(
+            ptree, root_uuid, rc, required_traits, usages_dict,
+            stats=stats, provider_uuids=provider_uuids)
         slack = free_total - float(amount)
-        _trace("RC=%s required=%.3f free_total=%.3f slack=%.3f", rc, float(amount), free_total, slack)
+        _trace("RC=%s required=%d free=%.3f slack=%.3f",
+               rc, amount, free_total, slack)
         slacks.append(slack)
-    if not slacks:
-        _trace("No RCs in group -> slack=0")
-        return UNMET_FLOOR
+
     gs = sum(slacks)
-    _trace("group_slack (sum over RC) -> %.3f", gs)
+    _trace("group_slack -> %.3f", gs)
     return gs
 
 
 # ------------------------------ Main weigher ------------------------------
 
 class AcceleratorWeigher(weights.BaseHostWeigher):
-    """Weigher scoring hosts using group-based RC+traits calculation and chosen policy."""
+    """Weigher scoring hosts by accelerator capacity using Placement data."""
 
     minval = 0
 
     def __init__(self):
         super().__init__()
-        # Per-scheduling-pass cache: {root_uuid: (ptree, usages_dict)}
-        # Cleared at the start of each weigh_objects() call to avoid stale data.
-        self._pass_cache = {}
-        # Cross-pass TTL cache for usage data: {root_uuid: (timestamp, usages_dict)}
-        # Persists across weigh_objects() calls; entries expire after usage_cache_seconds.
-        self._usage_cache = {}
+        self._pass_cache = {}    # {root_uuid: (ptree, usages_dict)}
+        self._usage_cache = {}   # {root_uuid: (timestamp, usages_dict)}
 
     def weigh_objects(self, weighed_obj_list, weight_properties):
         """Clear per-pass cache before weighing a new set of hosts."""
@@ -360,157 +346,170 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
         return super().weigh_objects(weighed_obj_list, weight_properties)
 
     def weight_multiplier(self, host_state):
-        """Override the weight multiplier.
-
-        Reads ``accelerator_weight_multiplier`` from aggregate metadata
-        to allow per-aggregate override, falling back to the config value.
-        """
+        """Return multiplier, allowing per-aggregate override."""
         return utils.get_weight_multiplier(
             host_state, 'accelerator_weight_multiplier',
             CONF.accelerator_weigher.accelerator_weight_multiplier)
 
-    def _weigh_object(self, host_state, weight_properties):
-        """Score host per policy.
+    # -- Private helpers --------------------------------------------------
 
-        sum-fit: score = sum of group_slacks (positive only).
-        product-fit: score = product of (group_slack + EPS) over groups (EPS avoids 0).
-        Any unmet group yields UNMET_FLOOR.
-        """
-        # Per-call stats collector
-        stats: Dict = {
-            "http_calls": 0,
-            "http_times_ms": 0.0,
-            "http_codes": {},
-            "notes": [],
-            "errors": [],
-        }
-
-        host_name = getattr(host_state, "host", "?")
-        _trace("==== weigh_object START host=%r policy=%s rc_pattern=%r mult=%.3f trace=%s ====",
-               host_name,
-               CONF.accelerator_weigher.policy,
-               CONF.accelerator_weigher.rc_pattern,
-               CONF.accelerator_weigher.accelerator_weight_multiplier,
-               CONF.accelerator_weigher.trace)
-
-        t_start = time.time()
-        client = _get_client()
-        rc_regex = _get_rc_regex()
-
-        # Use host_state.uuid directly as root RP UUID (compute node UUID ==
-        # root resource provider UUID in Placement), falling back to HTTP lookup.
+    def _resolve_root_uuid(self, host_state, client, stats):
+        """Return root RP UUID from host_state.uuid or HTTP lookup."""
         root_uuid = getattr(host_state, 'uuid', None)
         if root_uuid:
-            _trace("Using host_state.uuid=%s as root RP UUID (skipped HTTP lookup)", root_uuid)
+            _trace("Using host_state.uuid=%s as root RP UUID", root_uuid)
             stats["root_rp_source"] = "host_state.uuid"
         else:
             root_uuid = _lookup_root_rp_uuid(client, host_state, stats=stats)
             stats["root_rp_source"] = "http_lookup"
-        if not root_uuid:
-            LOG.debug("No root RP for host=%s; returning 0", host_name)
-            _trace("==== weigh_object END (no root RP) host=%r ====", host_name)
-            return 0.0
+        return root_uuid
 
-        groups = _extract_accel_groups(weight_properties, rc_regex, stats=stats)
-        if not groups:
-            LOG.debug("No accelerator request groups; host=%s returns 0", host_name)
-            _trace("==== weigh_object END (no accel groups) host=%r ====", host_name)
-            return 0.0
+    def _fetch_data(self, root_uuid, client, stats):
+        """Fetch ProviderTree + usages with 3-layer cache.
 
-        # Use per-pass cache to avoid redundant Placement calls for the same root RP.
+        Cache layers:
+          1. Per-pass cache (within a single weigh_objects call)
+          2. TTL cache (across weigh_objects calls, usage data only)
+          3. Placement API (concurrent ThreadPoolExecutor)
+
+        Returns: (ptree, usages_dict) or (None, {}) on failure.
+        """
+        # Layer 1: per-pass cache
         if root_uuid in self._pass_cache:
-            ptree, usages_dict = self._pass_cache[root_uuid]
             stats["cache_hit"] = "pass"
             _trace("Pass-cache hit for root_uuid=%s", root_uuid)
+            return self._pass_cache[root_uuid]
+
+        # Layer 2: TTL cache (usage data only; tree is always refreshed)
+        ttl = CONF.accelerator_weigher.usage_cache_seconds
+        cached_entry = self._usage_cache.get(root_uuid)
+        if cached_entry and ttl > 0 and (time.time() - cached_entry[0]) < ttl:
+            stats["cache_hit"] = "ttl"
+            _trace("TTL-cache hit for root_uuid=%s (age=%.1fs, ttl=%ds)",
+                   root_uuid, time.time() - cached_entry[0], ttl)
+            ptree, _ = _get_provider_tree_and_usages(
+                client, root_uuid, stats=stats, skip_usages=True)
+            usages_dict = cached_entry[1]
         else:
-            # Check TTL cache for usage data to avoid re-fetching across passes.
-            ttl = CONF.accelerator_weigher.usage_cache_seconds
-            cached_entry = self._usage_cache.get(root_uuid)
-            if cached_entry and ttl > 0 and (time.time() - cached_entry[0]) < ttl:
-                cached_usages = cached_entry[1]
-                stats["cache_hit"] = "ttl"
-                _trace("TTL-cache hit for root_uuid=%s (age=%.1fs, ttl=%ds)",
-                       root_uuid, time.time() - cached_entry[0], ttl)
-                # Still need a fresh ProviderTree (inventories/traits may change)
-                ptree, _ = _get_provider_tree_and_usages(client, root_uuid, stats=stats, skip_usages=True)
-                usages_dict = cached_usages
-            else:
-                ptree, usages_dict = _get_provider_tree_and_usages(client, root_uuid, stats=stats)
-                stats["cache_hit"] = False
-                # Update TTL cache
-                if ptree and ttl > 0:
-                    self._usage_cache[root_uuid] = (time.time(), usages_dict)
-            if ptree:
-                self._pass_cache[root_uuid] = (ptree, usages_dict)
-        if not ptree:
-            LOG.debug("Failed to build ProviderTree for host=%s; returning 0", host_name)
-            _trace("==== weigh_object END (no ProviderTree) host=%r ====", host_name)
+            # Layer 3: full Placement fetch
+            stats["cache_hit"] = False
+            ptree, usages_dict = _get_provider_tree_and_usages(
+                client, root_uuid, stats=stats)
+            if ptree and ttl > 0:
+                self._usage_cache[root_uuid] = (time.time(), usages_dict)
+
+        if ptree:
+            self._pass_cache[root_uuid] = (ptree, usages_dict)
+
+        return ptree, usages_dict
+
+    def _apply_policy(self, group_slacks):
+        """Compute final score from group slacks using configured policy.
+
+        Returns: float score, or UNMET_FLOOR if any group is unmet.
+        """
+        if any(gs == UNMET_FLOOR for gs in group_slacks):
+            return UNMET_FLOOR
+
+        policy = CONF.accelerator_weigher.policy
+        if policy == "sum-fit":
+            score = sum(group_slacks)
+        else:  # product-fit
+            score = 1.0
+            for gs in group_slacks:
+                score *= (gs + EPS)
+
+        _trace("policy=%s slacks=%s -> score=%.6f",
+               policy, group_slacks, score)
+        return float(score)
+
+    def _build_stats(self, stats, host_name, root_uuid, group_slacks,
+                     score, t_start):
+        """Populate final stats summary and emit trace."""
+        stats.update({
+            "final_score": score,
+            "host": host_name,
+            "root_rp": root_uuid,
+            "policy": CONF.accelerator_weigher.policy,
+            "multiplier": CONF.accelerator_weigher.accelerator_weight_multiplier,
+            "groups_slacks": group_slacks,
+            "duration_ms": (time.time() - t_start) * 1000.0,
+            "rc_pattern": CONF.accelerator_weigher.rc_pattern,
+        })
+        _trace("STATS SUMMARY:\n%s", pprint.pformat(stats))
+
+    # -- Core weighing ----------------------------------------------------
+
+    def _weigh_object(self, host_state, weight_properties):
+        """Score a host based on accelerator capacity and configured policy.
+
+        Pipeline:
+          1. Resolve root RP UUID
+          2. Extract accelerator request groups
+          3. Fetch ProviderTree + usages (with caching)
+          4. Compute per-group slack
+          5. Apply scoring policy
+        """
+        stats: Dict = {
+            "http_calls": 0,
+            "http_times_ms": 0.0,
+            "errors": [],
+        }
+        host_name = getattr(host_state, "host", "?")
+        t_start = time.time()
+
+        _trace("==== weigh_object START host=%r ====", host_name)
+
+        # 1. Resolve root RP UUID
+        client = _get_client()
+        root_uuid = self._resolve_root_uuid(host_state, client, stats)
+        if not root_uuid:
+            LOG.debug("No root RP for host=%s; returning 0", host_name)
             return 0.0
 
-        # Pre-fetch provider UUIDs once for reuse across all groups
+        # 2. Extract accelerator request groups
+        rc_regex = _get_rc_regex()
+        groups = _extract_accel_groups(weight_properties, rc_regex, stats=stats)
+        if not groups:
+            LOG.debug("No accelerator request groups; host=%s returns 0",
+                      host_name)
+            return 0.0
+
+        # 3. Fetch ProviderTree + usages
+        ptree, usages_dict = self._fetch_data(root_uuid, client, stats)
+        if not ptree:
+            LOG.debug("Failed to build ProviderTree for host=%s; returning 0",
+                      host_name)
+            return 0.0
+
+        # Pre-fetch provider UUIDs once for all groups
         try:
             provider_uuids = ptree.get_provider_uuids_in_tree(root_uuid)
         except ValueError:
             LOG.debug("Root %s not found in ProviderTree", root_uuid)
             return 0.0
 
-        group_slacks: List[float] = []
-
+        # 4. Compute per-group slack
+        group_slacks = []
         for idx, (accel_resources, req_traits) in enumerate(groups):
-            _trace("Processing group[%d] on host=%s ...", idx, host_name)
-            gs = _group_slack(ptree, root_uuid, accel_resources, req_traits, usages_dict, stats=stats, provider_uuids=provider_uuids)
+            _trace("Processing group[%d] on host=%s", idx, host_name)
+            gs = _group_slack(
+                ptree, root_uuid, accel_resources, req_traits,
+                usages_dict, stats=stats, provider_uuids=provider_uuids)
             group_slacks.append(gs)
             _trace("group[%d] -> slack=%.3f", idx, gs)
 
-        # Unmet if any group's slack == UNMET_FLOOR
-        if any(gs == UNMET_FLOOR for gs in group_slacks):
-            LOG.debug(
-                "Group unmet; host=%s slacks=%s -> score=%f",
-                getattr(host_state, "host", "?"), group_slacks, UNMET_FLOOR
-            )
-            # Summary stats
-            stats["final_score"] = UNMET_FLOOR
-            stats["host"] = host_name
-            stats["root_rp"] = root_uuid
-            stats["policy"] = CONF.accelerator_weigher.policy
-            stats["multiplier"] = CONF.accelerator_weigher.accelerator_weight_multiplier
-            stats["groups_slacks"] = group_slacks
-            stats["duration_ms"] = (time.time() - t_start) * 1000.0
-            _trace("STATS SUMMARY:\n%s", pprint.pformat(stats))
-            _trace("==== weigh_object END (unmet group -> score=%f) host=%r ====", UNMET_FLOOR, host_name)
-            return UNMET_FLOOR
-
-        policy = CONF.accelerator_weigher.policy
-        if policy == "sum-fit":
-            score = sum(group_slacks)
-            _trace("policy=%s score(before mult)=%.6f", policy, score)
-        else:  # product-fit: product of (slack + EPS) over groups (EPS avoids 0)
-            score = 1.0
-            for gs in group_slacks:
-                score *= (gs + EPS)
-            _trace("policy=%s product(group_slacks+EPS)=%.6f score(before mult)=%.6f", policy, score, score)
+        # 5. Apply scoring policy
+        score = self._apply_policy(group_slacks)
 
         LOG.debug(
-            "AcceleratorWeigher host=%s root_rp=%s policy=%s groups=%d slacks=%s score=%.6f",
-            host_name,
-            root_uuid,
-            policy,
-            len(group_slacks),
-            group_slacks,
-            float(score),
-        )
+            "AcceleratorWeigher host=%s root_rp=%s policy=%s "
+            "groups=%d slacks=%s score=%.6f",
+            host_name, root_uuid, CONF.accelerator_weigher.policy,
+            len(group_slacks), group_slacks, score)
 
-        # Summarize stats (helps analyze call overhead and skip reasons)
-        stats["final_score"] = float(score)
-        stats["host"] = host_name
-        stats["root_rp"] = root_uuid
-        stats["policy"] = policy
-        stats["multiplier"] = CONF.accelerator_weigher.accelerator_weight_multiplier
-        stats["groups_slacks"] = group_slacks
-        stats["duration_ms"] = (time.time() - t_start) * 1000.0
-        stats["rc_pattern"] = CONF.accelerator_weigher.rc_pattern
-
-        _trace("STATS SUMMARY:\n%s", pprint.pformat(stats))
-        _trace("==== weigh_object END host=%r score=%.6f ====", host_name, float(score))
-        return float(score)
-
+        self._build_stats(
+            stats, host_name, root_uuid, group_slacks, score, t_start)
+        _trace("==== weigh_object END host=%r score=%.6f ====",
+               host_name, score)
+        return score

--- a/nova/scheduler/weights/accelerator.py
+++ b/nova/scheduler/weights/accelerator.py
@@ -22,8 +22,8 @@ import pprint
 from typing import Dict, List, Optional, Tuple, Set
 from urllib.parse import quote
 
-from oslo_config import cfg
 from oslo_log import log as logging
+import nova.conf
 from nova import context
 from nova.compute import provider_tree
 from nova.scheduler import weights
@@ -31,37 +31,7 @@ from nova.scheduler.client import report as placement_report
 
 LOG = logging.getLogger(__name__)
 
-_ACCEL_OPTS = [
-    cfg.StrOpt(
-        "rc_pattern",
-        default=r"(?i)^(CUSTOM_)?(FPGA|PGPU|VGPU|QAT|NIC|SSD|AICHIP)$",
-        help=(
-            "Regex to identify accelerator RCs included in scoring. "
-            "Matches: FPGA, PGPU, VGPU, CUSTOM_QAT, CUSTOM_NIC, CUSTOM_SSD, CUSTOM_AICHIP."
-        ),
-    ),
-    cfg.StrOpt(
-        "policy",
-        default="sum-fit",
-        choices=["sum-fit", "product-fit"],
-        help=("Scoring policy: "
-              "sum-fit (sum of group slacks) or "
-              "product-fit (product of group_slacks with epsilon)."),
-    ),
-    cfg.FloatOpt(
-        "accelerator_weight_multiplier",
-        default=1.0,
-        help="Multiplier applied to the final accelerator score.",
-    ),
-    cfg.BoolOpt(
-        "trace",
-        default=False,
-        help="Emit verbose DEBUG logs for detailed flow tracing.",
-    ),
-]
-
-CONF = cfg.CONF
-CONF.register_opts(_ACCEL_OPTS, group="accelerator_weigher")
+CONF = nova.conf.CONF
 
 EPS = 1e-6
 UNMET_FLOOR = -1e6

--- a/nova/scheduler/weights/accelerator.py
+++ b/nova/scheduler/weights/accelerator.py
@@ -354,6 +354,17 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
 
     minval = 0
 
+    def __init__(self):
+        super().__init__()
+        # Per-scheduling-pass cache: {root_uuid: (ptree, usages_dict)}
+        # Cleared at the start of each weigh_objects() call to avoid stale data.
+        self._pass_cache = {}
+
+    def weigh_objects(self, weighed_obj_list, weight_properties):
+        """Clear per-pass cache before weighing a new set of hosts."""
+        self._pass_cache = {}
+        return super().weigh_objects(weighed_obj_list, weight_properties)
+
     def weight_multiplier(self, host_state):
         return CONF.accelerator_weigher.accelerator_weight_multiplier
 
@@ -385,7 +396,15 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
         client = _get_client()
         rc_regex = _get_rc_regex()
 
-        root_uuid = _lookup_root_rp_uuid(client, host_state, stats=stats)
+        # Use host_state.uuid directly as root RP UUID (compute node UUID ==
+        # root resource provider UUID in Placement), falling back to HTTP lookup.
+        root_uuid = getattr(host_state, 'uuid', None)
+        if root_uuid:
+            _trace("Using host_state.uuid=%s as root RP UUID (skipped HTTP lookup)", root_uuid)
+            stats["root_rp_source"] = "host_state.uuid"
+        else:
+            root_uuid = _lookup_root_rp_uuid(client, host_state, stats=stats)
+            stats["root_rp_source"] = "http_lookup"
         if not root_uuid:
             LOG.debug("No root RP for host=%s; returning 0", host_name)
             _trace("==== weigh_object END (no root RP) host=%r ====", host_name)
@@ -397,8 +416,16 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
             _trace("==== weigh_object END (no accel groups) host=%r ====", host_name)
             return 0.0
 
-        # Get ProviderTree once and reuse for all groups
-        ptree, usages_dict = _get_provider_tree_and_usages(client, root_uuid, stats=stats)
+        # Use per-pass cache to avoid redundant Placement calls for the same root RP.
+        if root_uuid in self._pass_cache:
+            ptree, usages_dict = self._pass_cache[root_uuid]
+            stats["cache_hit"] = True
+            _trace("Cache hit for root_uuid=%s (skipped ProviderTree + usage HTTP calls)", root_uuid)
+        else:
+            ptree, usages_dict = _get_provider_tree_and_usages(client, root_uuid, stats=stats)
+            if ptree:
+                self._pass_cache[root_uuid] = (ptree, usages_dict)
+            stats["cache_hit"] = False
         if not ptree:
             LOG.debug("Failed to build ProviderTree for host=%s; returning 0", host_name)
             _trace("==== weigh_object END (no ProviderTree) host=%r ====", host_name)

--- a/nova/scheduler/weights/accelerator.py
+++ b/nova/scheduler/weights/accelerator.py
@@ -20,6 +20,7 @@ import re
 import time
 import pprint
 from typing import Dict, List, Optional, Tuple, Set
+from urllib.parse import quote
 
 from oslo_config import cfg
 from oslo_log import log as logging
@@ -63,7 +64,20 @@ CONF = cfg.CONF
 CONF.register_opts(_ACCEL_OPTS, group="accelerator_weigher")
 
 EPS = 1e-6
-UNMET_FLOOR = float("-inf")
+UNMET_FLOOR = -1e6
+
+_rc_regex_cache = None
+_rc_regex_pattern = None
+
+
+def _get_rc_regex() -> re.Pattern:
+    """Return compiled regex for rc_pattern, cached across calls."""
+    global _rc_regex_cache, _rc_regex_pattern
+    pattern = CONF.accelerator_weigher.rc_pattern
+    if _rc_regex_cache is None or pattern != _rc_regex_pattern:
+        _rc_regex_cache = re.compile(pattern)
+        _rc_regex_pattern = pattern
+    return _rc_regex_cache
 
 # ------------------------------ trace helper ------------------------------
 
@@ -94,7 +108,7 @@ def _lookup_root_rp_uuid(client: placement_report.SchedulerReportClient, host_st
         return None
 
     t0 = time.time()
-    url = f"/resource_providers?name={name}"
+    url = f"/resource_providers?name={quote(name)}"
     _trace("HTTP GET %s", url)
     resp = client.get(url)
     dt = (time.time() - t0) * 1000.0
@@ -255,18 +269,20 @@ def _sum_free_for_rc_with_traits(
     required_traits: Set[str],
     usages_dict: Dict[str, Dict[str, float]],
     stats: Dict,
+    provider_uuids: Optional[List[str]] = None,
 ) -> float:
     """Sum free units for (RC + required_traits) across child RPs using ProviderTree."""
     _trace("Sum free across tree: RC=%s required_traits=%s", rc_name, sorted(required_traits))
     total_free = 0.0
 
-    # Get all provider UUIDs in tree (excluding root)
-    try:
-        provider_uuids = ptree.get_provider_uuids_in_tree(root_uuid)
-    except ValueError:
-        _trace("Root %s not found in tree", root_uuid)
-        stats["errors"].append("root-not-in-tree")
-        return 0.0
+    # Reuse pre-fetched provider UUIDs if available
+    if provider_uuids is None:
+        try:
+            provider_uuids = ptree.get_provider_uuids_in_tree(root_uuid)
+        except ValueError:
+            _trace("Root %s not found in tree", root_uuid)
+            stats["errors"].append("root-not-in-tree")
+            return 0.0
 
     stats["providers_iterated"] = stats.get("providers_iterated", 0) + len(provider_uuids)
     _trace("Traversing %d providers under root=%s", len(provider_uuids), root_uuid)
@@ -313,12 +329,13 @@ def _group_slack(
     required_traits: Set[str],
     usages_dict: Dict[str, Dict[str, float]],
     stats: Dict,
+    provider_uuids: Optional[List[str]] = None,
 ) -> float:
     """Compute group slack: sum over RC of (total_free_rc - required_rc)."""
     _trace("Compute group_slack for resources=%s traits=%s", accel_resources, sorted(required_traits))
     slacks: List[float] = []
     for rc, amount in accel_resources.items():
-        free_total = _sum_free_for_rc_with_traits(ptree, root_uuid, rc, required_traits, usages_dict, stats=stats)
+        free_total = _sum_free_for_rc_with_traits(ptree, root_uuid, rc, required_traits, usages_dict, stats=stats, provider_uuids=provider_uuids)
         slack = free_total - float(amount)
         _trace("RC=%s required=%.3f free_total=%.3f slack=%.3f", rc, float(amount), free_total, slack)
         slacks.append(slack)
@@ -334,6 +351,8 @@ def _group_slack(
 
 class AcceleratorWeigher(weights.BaseHostWeigher):
     """Weigher scoring hosts using group-based RC+traits calculation and chosen policy."""
+
+    minval = 0
 
     def weight_multiplier(self, host_state):
         return CONF.accelerator_weigher.accelerator_weight_multiplier
@@ -364,7 +383,7 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
 
         t_start = time.time()
         client = _get_client()
-        rc_regex = re.compile(CONF.accelerator_weigher.rc_pattern)
+        rc_regex = _get_rc_regex()
 
         root_uuid = _lookup_root_rp_uuid(client, host_state, stats=stats)
         if not root_uuid:
@@ -385,11 +404,18 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
             _trace("==== weigh_object END (no ProviderTree) host=%r ====", host_name)
             return 0.0
 
+        # Pre-fetch provider UUIDs once for reuse across all groups
+        try:
+            provider_uuids = ptree.get_provider_uuids_in_tree(root_uuid)
+        except ValueError:
+            LOG.debug("Root %s not found in ProviderTree", root_uuid)
+            return 0.0
+
         group_slacks: List[float] = []
 
         for idx, (accel_resources, req_traits) in enumerate(groups):
             _trace("Processing group[%d] on host=%s ...", idx, host_name)
-            gs = _group_slack(ptree, root_uuid, accel_resources, req_traits, usages_dict, stats=stats)
+            gs = _group_slack(ptree, root_uuid, accel_resources, req_traits, usages_dict, stats=stats, provider_uuids=provider_uuids)
             group_slacks.append(gs)
             _trace("group[%d] -> slack=%.3f", idx, gs)
 
@@ -397,7 +423,7 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
         if any(gs == UNMET_FLOOR for gs in group_slacks):
             LOG.debug(
                 "Group unmet; host=%s slacks=%s -> score=%f",
-                getattr(host_state, "host", "?"), group_slacks
+                getattr(host_state, "host", "?"), group_slacks, UNMET_FLOOR
             )
             # Summary stats
             stats["final_score"] = UNMET_FLOOR
@@ -413,9 +439,8 @@ class AcceleratorWeigher(weights.BaseHostWeigher):
 
         policy = CONF.accelerator_weigher.policy
         if policy == "sum-fit":
-            total_slack = sum(gs for gs in group_slacks if gs > 0)
-            score = total_slack
-            _trace("policy=%s total_slack=%.6f score(before mult)=%.6f", policy, total_slack, score)
+            score = sum(group_slacks)
+            _trace("policy=%s score(before mult)=%.6f", policy, score)
         else:  # product-fit: product of (slack + EPS) over groups (EPS avoids 0)
             score = 1.0
             for gs in group_slacks:

--- a/nova/tests/unit/scheduler/weights/test_weights_accelerator.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_accelerator.py
@@ -765,3 +765,84 @@ class AcceleratorWeigherTestCase(test.NoDBTestCase):
         # This tests the BaseWeigher.minval=0 setting
         weigher = accelerator.AcceleratorWeigher()
         self.assertEqual(0, weigher.minval)
+
+    # ---------- Flavor-driven dynamic policy ----------
+
+    def test_flavor_policy_override(self):
+        """Flavor extra_spec overrides global config policy."""
+        # Global config = sum-fit
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {
+                'child-1': FakeProviderData(
+                    inventory={'PGPU': {'total': 6, 'reserved': 0}},
+                    traits=set()),
+                'child-2': FakeProviderData(
+                    inventory={'FPGA': {'total': 3, 'reserved': 0}},
+                    traits=set()),
+            },
+            usages_dict={
+                'child-1': {'PGPU': 0},
+                'child-2': {'FPGA': 1},
+            })
+
+        host = self._make_host('host1', 'node1', root_uuid)
+
+        # Create spec with flavor extra_spec overriding to product-fit
+        spec = self._make_spec([
+            ({"PGPU": 2}, set()),  # slack = 6 - 2 = 4
+            ({"FPGA": 1}, set()),  # slack = 2 - 1 = 1
+        ])
+        # Attach flavor with extra_specs
+        spec.flavor = type('FakeFlavor', (), {
+            'extra_specs': {'accelerator_weigher:policy': 'product-fit'}
+        })()
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # With product-fit (from flavor override): (4+eps)*(1+eps) ~= 4
+        # With sum-fit (global config): 4 + 1 = 5
+        self.assertAlmostEqual(4.0, score, places=4)
+
+    def test_flavor_invalid_policy_falls_back_to_config(self):
+        """Invalid flavor policy value falls back to global config."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 0}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([({"PGPU": 1}, set())])
+        spec.flavor = type('FakeFlavor', (), {
+            'extra_specs': {'accelerator_weigher:policy': 'invalid-policy'}
+        })()
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # Falls back to sum-fit: slack = 4 - 1 = 3
+        self.assertEqual(3.0, score)
+
+    def test_flavor_no_extra_specs_uses_config(self):
+        """When flavor has no extra_specs, use global config."""
+        self.flags(policy='product-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 5, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 1}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([({"PGPU": 2}, set())])
+        # No flavor attribute at all
+        score = self.accel_weigher._weigh_object(host, spec)
+        # product-fit: (2 + EPS) ≈ 2.0
+        self.assertAlmostEqual(2.0, score, places=4)

--- a/nova/tests/unit/scheduler/weights/test_weights_accelerator.py
+++ b/nova/tests/unit/scheduler/weights/test_weights_accelerator.py
@@ -1,0 +1,767 @@
+# Copyright 2024 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+"""Tests for Scheduler Accelerator weights."""
+
+from unittest import mock
+
+from nova import objects
+from nova.scheduler import weights
+from nova.scheduler.weights import accelerator
+from nova import test
+from nova.tests.unit.scheduler import fakes
+
+
+# ----------------------------- Fake helpers --------------------------------
+
+class FakeProviderData:
+    """Mimics the object returned by ProviderTree.data(uuid)."""
+
+    def __init__(self, inventory=None, traits=None):
+        self.inventory = inventory or {}
+        self.traits = traits or set()
+
+
+class FakeProviderTree:
+    """Minimal ProviderTree mock for testing."""
+
+    def __init__(self, root_uuid, providers):
+        """
+        :param root_uuid: UUID of the root provider
+        :param providers: dict {uuid: FakeProviderData}
+        """
+        self._root_uuid = root_uuid
+        self._providers = {root_uuid: FakeProviderData()}
+        self._providers.update(providers)
+
+    def get_provider_uuids_in_tree(self, root_uuid):
+        if root_uuid != self._root_uuid:
+            raise ValueError("Root %s not found" % root_uuid)
+        return list(self._providers.keys())
+
+    def data(self, rp_uuid):
+        if rp_uuid not in self._providers:
+            raise ValueError("RP %s not found" % rp_uuid)
+        return self._providers[rp_uuid]
+
+
+class FakeRequestGroup:
+    """Mimics a RequestGroup with resources and required_traits."""
+
+    def __init__(self, resources, required_traits=None):
+        self.resources = resources
+        self.required_traits = required_traits or set()
+
+
+class FakeRequestSpec:
+    """Mimics a RequestSpec with requested_resources."""
+
+    def __init__(self, groups=None):
+        self.requested_resources = groups or []
+
+
+class FakeResponse:
+    """Mimics an HTTP response object."""
+
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+
+    def json(self):
+        return self._json_data
+
+
+def _make_usage_response(usages):
+    """Create a FakeResponse for /resource_providers/{uuid}/usages."""
+    return FakeResponse(200, {"usages": usages})
+
+
+# ----------------------------- Test cases ----------------------------------
+
+class AcceleratorWeigherTestCase(test.NoDBTestCase):
+    """Tests for AcceleratorWeigher."""
+
+    def setUp(self):
+        super(AcceleratorWeigherTestCase, self).setUp()
+        self.weight_handler = weights.HostWeightHandler()
+        self.weighers = [accelerator.AcceleratorWeigher()]
+        self.accel_weigher = accelerator.AcceleratorWeigher()
+
+        # Patch _get_client to return a mock
+        self.mock_client = mock.MagicMock()
+        patcher = mock.patch(
+            'nova.scheduler.weights.accelerator._get_client',
+            return_value=self.mock_client)
+        self.addCleanup(patcher.stop)
+        patcher.start()
+
+        # Patch context.get_context
+        ctx_patcher = mock.patch(
+            'nova.scheduler.weights.accelerator.context.get_context',
+            return_value=mock.MagicMock())
+        self.addCleanup(ctx_patcher.stop)
+        ctx_patcher.start()
+
+    def _make_host(self, host, node, uuid, aggregates=None):
+        """Create a FakeHostState with uuid."""
+        host_state = fakes.FakeHostState(host, node, {'uuid': uuid})
+        if aggregates:
+            host_state.aggregates = aggregates
+        return host_state
+
+    def _setup_provider_tree(self, root_uuid, providers, usages_dict=None):
+        """Set up mock client to return a FakeProviderTree.
+
+        :param root_uuid: Root RP UUID
+        :param providers: dict {child_uuid: FakeProviderData}
+        :param usages_dict: dict {child_uuid: {rc: usage}}
+        """
+        ptree = FakeProviderTree(root_uuid, providers)
+        self.mock_client.get_provider_tree_and_ensure_root.return_value = ptree
+
+        usages_dict = usages_dict or {}
+
+        def _mock_get(url):
+            # Match /resource_providers/{uuid}/usages
+            for rp_uuid, usages in usages_dict.items():
+                if url == f"/resource_providers/{rp_uuid}/usages":
+                    return _make_usage_response(usages)
+            return _make_usage_response({})
+
+        self.mock_client.get.side_effect = _mock_get
+        return ptree
+
+    def _make_spec(self, groups):
+        """Create a FakeRequestSpec from a list of (resources, traits) tuples.
+
+        :param groups: list of (resources_dict, traits_set) tuples
+        """
+        request_groups = [
+            FakeRequestGroup(res, traits) for res, traits in groups
+        ]
+        return FakeRequestSpec(request_groups)
+
+    # ---------- Basic scoring tests ----------
+
+    def test_no_accel_groups_returns_zero(self):
+        """When request has no accelerator groups, score should be 0."""
+        host = self._make_host('host1', 'node1', 'uuid-root-1')
+        spec = FakeRequestSpec()  # no requested_resources
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        self.assertEqual(0.0, score)
+
+    def test_no_uuid_no_root_rp_returns_zero(self):
+        """When host has no UUID and HTTP lookup fails, score should be 0."""
+        host = fakes.FakeHostState('host1', 'node1', {})
+        # _lookup_root_rp_uuid will be called; make it return empty
+        self.mock_client.get.return_value = FakeResponse(
+            200, {"resource_providers": []})
+
+        spec = self._make_spec([
+            ({"PGPU": 1}, set()),
+        ])
+        score = self.accel_weigher._weigh_object(host, spec)
+        self.assertEqual(0.0, score)
+
+    def test_sum_fit_single_group(self):
+        """Sum-fit with a single group: score = slack."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        # Child RP with 4 PGPU total, 0 reserved, 1 used → 3 free
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 1}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 2}, set()),  # request 2 PGPU
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # free=3, required=2, slack=1, score=sum([1])=1.0
+        self.assertEqual(1.0, score)
+
+    def test_sum_fit_multiple_groups(self):
+        """Sum-fit with multiple groups: score = sum of slacks."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {
+                'child-1': FakeProviderData(
+                    inventory={'PGPU': {'total': 6, 'reserved': 0}},
+                    traits=set()),
+                'child-2': FakeProviderData(
+                    inventory={'FPGA': {'total': 4, 'reserved': 0}},
+                    traits=set()),
+            },
+            usages_dict={
+                'child-1': {'PGPU': 2},  # 4 free
+                'child-2': {'FPGA': 1},  # 3 free
+            })
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 1}, set()),  # slack = 4 - 1 = 3
+            ({"FPGA": 2}, set()),  # slack = 3 - 2 = 1
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # score = sum([3, 1]) = 4.0
+        self.assertEqual(4.0, score)
+
+    def test_sum_fit_negative_slack_included(self):
+        """Sum-fit includes negative slacks (not filtered out)."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={
+                    'PGPU': {'total': 5, 'reserved': 0},
+                    'FPGA': {'total': 1, 'reserved': 0},
+                },
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 0, 'FPGA': 0}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 2}, set()),  # slack = 5 - 2 = 3
+            ({"FPGA": 3}, set()),  # slack = 1 - 3 = -2
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # score = sum([3, -2]) = 1.0 (negative slack IS included)
+        self.assertEqual(1.0, score)
+
+    def test_product_fit_single_group(self):
+        """Product-fit with single group: score = (slack + EPS)."""
+        self.flags(policy='product-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 5, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 1}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 2}, set()),  # slack = 4 - 2 = 2
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # score = (2 + EPS) ≈ 2.000001
+        self.assertAlmostEqual(2.0, score, places=4)
+
+    def test_product_fit_multiple_groups(self):
+        """Product-fit with multiple groups: score = product of (slack+EPS)."""
+        self.flags(policy='product-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {
+                'child-1': FakeProviderData(
+                    inventory={'PGPU': {'total': 5, 'reserved': 0}},
+                    traits=set()),
+                'child-2': FakeProviderData(
+                    inventory={'FPGA': {'total': 6, 'reserved': 0}},
+                    traits=set()),
+            },
+            usages_dict={
+                'child-1': {'PGPU': 2},  # 3 free
+                'child-2': {'FPGA': 1},  # 5 free
+            })
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 1}, set()),  # slack = 3 - 1 = 2
+            ({"FPGA": 2}, set()),  # slack = 5 - 2 = 3
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # score ≈ (2 + EPS) * (3 + EPS) ≈ 6.0
+        self.assertAlmostEqual(6.0, score, places=4)
+
+    # ---------- Unmet group tests ----------
+
+    def test_unmet_group_non_matching_rc_returns_zero(self):
+        """When request has no RC matching rc_pattern, returns 0 (no groups)."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 0}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            # RC doesn't match default rc_pattern → group skipped → 0
+            ({"CUSTOM_UNKNOWN_ACCEL": 1}, set()),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        self.assertEqual(0.0, score)
+
+    def test_group_slack_empty_resources_returns_unmet_floor(self):
+        """_group_slack returns UNMET_FLOOR when accel_resources is empty."""
+        ptree = FakeProviderTree('root-1', {})
+        stats = {"errors": []}
+        result = accelerator._group_slack(
+            ptree, 'root-1', {}, set(), {}, stats)
+        self.assertEqual(accelerator.UNMET_FLOOR, result)
+
+    def test_unmet_floor_clamped_by_minval(self):
+        """UNMET_FLOOR is clamped to minval=0 during normalization."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid_1 = 'root-1'
+        root_uuid_2 = 'root-2'
+
+        # host1: has PGPU capacity → positive score
+        ptree1 = FakeProviderTree(
+            root_uuid_1,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                traits=set())})
+        # host2: no matching RC → UNMET_FLOOR
+        ptree2 = FakeProviderTree(root_uuid_2, {})
+
+        def _mock_get_tree(ctx, root_uuid):
+            if root_uuid == root_uuid_1:
+                return ptree1
+            return ptree2
+
+        self.mock_client.get_provider_tree_and_ensure_root.side_effect = \
+            _mock_get_tree
+        self.mock_client.get.side_effect = lambda url: _make_usage_response(
+            {'PGPU': 0})
+
+        host1 = self._make_host('host1', 'node1', root_uuid_1)
+        host2 = self._make_host('host2', 'node2', root_uuid_2)
+
+        spec = self._make_spec([
+            ({"PGPU": 2}, set()),
+        ])
+
+        weigher = accelerator.AcceleratorWeigher()
+        # weigh_objects applies minval clamping
+        weighed = self.weight_handler.get_weighed_objects(
+            [weigher], [host1, host2], spec)
+
+        # host1 should win with positive weight, host2 should get 0
+        self.assertEqual('host1', weighed[0].obj.host)
+        self.assertGreaterEqual(weighed[-1].weight, 0.0)
+
+    # ---------- Traits filtering tests ----------
+
+    def test_traits_filter_matching(self):
+        """RPs with matching traits contribute to free count."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {
+                'child-1': FakeProviderData(
+                    inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                    traits={'CUSTOM_GPU_NVIDIA'}),
+                'child-2': FakeProviderData(
+                    inventory={'PGPU': {'total': 2, 'reserved': 0}},
+                    traits={'CUSTOM_GPU_AMD'}),  # different trait
+            },
+            usages_dict={
+                'child-1': {'PGPU': 0},
+                'child-2': {'PGPU': 0},
+            })
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 1}, {"CUSTOM_GPU_NVIDIA"}),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # Only child-1 matches traits: free=4, required=1, slack=3
+        self.assertEqual(3.0, score)
+
+    def test_traits_filter_no_match(self):
+        """When no RP matches required traits, group slack → UNMET_FLOOR."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                traits={'CUSTOM_GPU_AMD'})},
+            usages_dict={'child-1': {'PGPU': 0}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 1}, {"CUSTOM_GPU_NVIDIA"}),  # no match
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # No matching RP → free=0, required=1, slack=-1
+        # slack is -1 (not UNMET_FLOOR because the group had RCs, just no
+        # matching providers)
+        self.assertEqual(-1.0, score)
+
+    # ---------- Reserved and usage accounting ----------
+
+    def test_reserved_subtracted(self):
+        """Reserved inventory is subtracted from total."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 10, 'reserved': 3}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 2}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 1}, set()),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # free = 10 - 3 - 2 = 5, slack = 5 - 1 = 4
+        self.assertEqual(4.0, score)
+
+    def test_fully_used_returns_negative_slack(self):
+        """When all capacity is used, slack is negative."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 2, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 2}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 1}, set()),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # free = max(2 - 0 - 2, 0) = 0, slack = 0 - 1 = -1
+        self.assertEqual(-1.0, score)
+
+    # ---------- Multiple children aggregated ----------
+
+    def test_multiple_children_summed(self):
+        """Free units across multiple children are summed."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {
+                'child-1': FakeProviderData(
+                    inventory={'PGPU': {'total': 3, 'reserved': 0}},
+                    traits=set()),
+                'child-2': FakeProviderData(
+                    inventory={'PGPU': {'total': 5, 'reserved': 1}},
+                    traits=set()),
+            },
+            usages_dict={
+                'child-1': {'PGPU': 1},  # 2 free
+                'child-2': {'PGPU': 2},  # 2 free (5-1-2)
+            })
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"PGPU": 1}, set()),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # total_free = 2 + 2 = 4, slack = 4 - 1 = 3
+        self.assertEqual(3.0, score)
+
+    # ---------- Multiplier tests ----------
+
+    def test_weight_multiplier_default(self):
+        """Default multiplier is 1.0."""
+        host = self._make_host('host1', 'node1', 'uuid-1')
+        self.assertEqual(1.0, self.accel_weigher.weight_multiplier(host))
+
+    def test_weight_multiplier_config(self):
+        """Multiplier reads from config."""
+        self.flags(accelerator_weight_multiplier=2.5,
+                   group='accelerator_weigher')
+        host = self._make_host('host1', 'node1', 'uuid-1')
+        self.assertEqual(2.5, self.accel_weigher.weight_multiplier(host))
+
+    def test_weight_multiplier_aggregate_override(self):
+        """Aggregate metadata overrides config multiplier."""
+        self.flags(accelerator_weight_multiplier=1.0,
+                   group='accelerator_weigher')
+        aggs = [
+            objects.Aggregate(
+                id=1,
+                name='gpu-agg',
+                hosts=['host1'],
+                metadata={'accelerator_weight_multiplier': '3.0'},
+            )]
+        host = self._make_host('host1', 'node1', 'uuid-1', aggregates=aggs)
+        self.assertEqual(3.0, self.accel_weigher.weight_multiplier(host))
+
+    def test_weight_multiplier_aggregate_min_wins(self):
+        """When host is in multiple aggregates, minimum value wins."""
+        self.flags(accelerator_weight_multiplier=1.0,
+                   group='accelerator_weigher')
+        aggs = [
+            objects.Aggregate(
+                id=1,
+                name='agg1',
+                hosts=['host1'],
+                metadata={'accelerator_weight_multiplier': '5.0'},
+            ),
+            objects.Aggregate(
+                id=2,
+                name='agg2',
+                hosts=['host1'],
+                metadata={'accelerator_weight_multiplier': '2.0'},
+            )]
+        host = self._make_host('host1', 'node1', 'uuid-1', aggregates=aggs)
+        self.assertEqual(2.0, self.accel_weigher.weight_multiplier(host))
+
+    # ---------- Host UUID optimization ----------
+
+    def test_host_uuid_skips_http_lookup(self):
+        """When host_state.uuid is available, no HTTP lookup is made."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-uuid-direct'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 2, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 0}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([({"PGPU": 1}, set())])
+
+        self.accel_weigher._weigh_object(host, spec)
+
+        # get_provider_tree_and_ensure_root should be called with root_uuid
+        self.mock_client.get_provider_tree_and_ensure_root.assert_called_once()
+        # No call to GET /resource_providers?name=... since uuid was used
+        for call in self.mock_client.get.call_args_list:
+            url = call[0][0]
+            self.assertNotIn('/resource_providers?name=', url)
+
+    def test_fallback_to_http_lookup_when_no_uuid(self):
+        """When host_state.uuid is None, falls back to HTTP lookup."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-from-lookup'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 2, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 0}})
+
+        # Override get side_effect to handle both RP lookup and usages
+        original_get = self.mock_client.get.side_effect
+
+        def _mock_get(url):
+            if '/resource_providers?name=' in url:
+                return FakeResponse(200, {
+                    "resource_providers": [{"uuid": root_uuid}]
+                })
+            return original_get(url)
+
+        self.mock_client.get.side_effect = _mock_get
+
+        # Host with no uuid
+        host = fakes.FakeHostState('host1', 'node1', {})
+        spec = self._make_spec([({"PGPU": 1}, set())])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # Should still work via HTTP lookup
+        self.assertEqual(1.0, score)  # free=2, required=1, slack=1
+
+    # ---------- Cache tests ----------
+
+    def test_pass_cache_cleared_on_weigh_objects(self):
+        """Cache is cleared at the start of each weigh_objects call."""
+        weigher = accelerator.AcceleratorWeigher()
+        weigher._pass_cache = {'stale-root': ('ptree', 'usages')}
+
+        # weigh_objects should clear cache (even with empty list)
+        weigher.weigh_objects([], FakeRequestSpec())
+        self.assertEqual({}, weigher._pass_cache)
+
+    # ---------- RC pattern matching ----------
+
+    def test_non_accel_rc_ignored(self):
+        """Non-accelerator RCs (e.g., VCPU, MEMORY_MB) are ignored."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'PGPU': 0}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        # Mix of accel and non-accel RCs
+        spec = self._make_spec([
+            ({"VCPU": 4, "MEMORY_MB": 8192, "PGPU": 1}, set()),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # Only PGPU is matched: free=4, required=1, slack=3
+        self.assertEqual(3.0, score)
+
+    def test_custom_rc_pattern(self):
+        """Custom rc_pattern config matches different RCs."""
+        self.flags(rc_pattern=r'^CUSTOM_MYACCEL$',
+                   policy='sum-fit', group='accelerator_weigher')
+        # Clear cached regex
+        accelerator._rc_regex_cache = None
+        accelerator._rc_regex_pattern = None
+
+        root_uuid = 'root-1'
+        self._setup_provider_tree(
+            root_uuid,
+            {'child-1': FakeProviderData(
+                inventory={'CUSTOM_MYACCEL': {'total': 10, 'reserved': 0}},
+                traits=set())},
+            usages_dict={'child-1': {'CUSTOM_MYACCEL': 3}})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        spec = self._make_spec([
+            ({"CUSTOM_MYACCEL": 2}, set()),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # free=7, required=2, slack=5
+        self.assertEqual(5.0, score)
+
+    # ---------- Edge cases ----------
+
+    def test_provider_tree_failure_returns_zero(self):
+        """When get_provider_tree_and_ensure_root fails, score is 0."""
+        self.mock_client.get_provider_tree_and_ensure_root.side_effect = \
+            Exception("placement unavailable")
+
+        host = self._make_host('host1', 'node1', 'root-1')
+        spec = self._make_spec([({"PGPU": 1}, set())])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        self.assertEqual(0.0, score)
+
+    def test_empty_group_resources_returns_unmet(self):
+        """A request group with only non-accel RCs → group is skipped."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+        root_uuid = 'root-1'
+
+        self._setup_provider_tree(root_uuid, {})
+
+        host = self._make_host('host1', 'node1', root_uuid)
+        # Only non-accel RCs
+        spec = self._make_spec([
+            ({"VCPU": 2, "MEMORY_MB": 4096}, set()),
+        ])
+
+        score = self.accel_weigher._weigh_object(host, spec)
+        # No accel groups extracted → returns 0
+        self.assertEqual(0.0, score)
+
+    # ---------- Integration: multiple hosts weighed ----------
+
+    def test_multiple_hosts_ranked_by_capacity(self):
+        """Hosts with more free accelerator capacity score higher."""
+        self.flags(policy='sum-fit', group='accelerator_weigher')
+
+        root_1 = 'root-host1'
+        root_2 = 'root-host2'
+        root_3 = 'root-host3'
+
+        trees = {
+            root_1: FakeProviderTree(root_1, {
+                'c1': FakeProviderData(
+                    inventory={'PGPU': {'total': 8, 'reserved': 0}},
+                    traits=set())}),
+            root_2: FakeProviderTree(root_2, {
+                'c2': FakeProviderData(
+                    inventory={'PGPU': {'total': 4, 'reserved': 0}},
+                    traits=set())}),
+            root_3: FakeProviderTree(root_3, {
+                'c3': FakeProviderData(
+                    inventory={'PGPU': {'total': 2, 'reserved': 0}},
+                    traits=set())}),
+        }
+        usages = {
+            'c1': {'PGPU': 0},  # 8 free
+            'c2': {'PGPU': 0},  # 4 free
+            'c3': {'PGPU': 0},  # 2 free
+        }
+
+        def _mock_get_tree(ctx, root_uuid):
+            return trees[root_uuid]
+
+        self.mock_client.get_provider_tree_and_ensure_root.side_effect = \
+            _mock_get_tree
+
+        def _mock_get(url):
+            for rp_uuid, usage in usages.items():
+                if rp_uuid in url:
+                    return _make_usage_response(usage)
+            return _make_usage_response({})
+
+        self.mock_client.get.side_effect = _mock_get
+
+        hosts = [
+            self._make_host('host1', 'node1', root_1),
+            self._make_host('host2', 'node2', root_2),
+            self._make_host('host3', 'node3', root_3),
+        ]
+
+        spec = self._make_spec([({"PGPU": 1}, set())])
+
+        weigher = accelerator.AcceleratorWeigher()
+        weighed = self.weight_handler.get_weighed_objects(
+            [weigher], hosts, spec)
+
+        # host1 (slack=7) should rank first, host3 (slack=1) last
+        self.assertEqual('host1', weighed[0].obj.host)
+        self.assertEqual('host3', weighed[-1].obj.host)
+
+    def test_minval_zero_prevents_negative_normalization(self):
+        """minval=0 ensures negative scores normalize to 0, not below."""
+        # This tests the BaseWeigher.minval=0 setting
+        weigher = accelerator.AcceleratorWeigher()
+        self.assertEqual(0, weigher.minval)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ allowlist_externals =
   rm
   env
   make
-install_command = python -I -m pip install -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/2024.1} {opts} {packages}
+install_command = python -I -m pip install -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/openkcloud/kcloud-requirements/kcloud/2024.1/upper-constraints.txt} {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US


### PR DESCRIPTION
  ## Summary

  This PR adds **AcceleratorWeigher**, a Nova scheduler weigher that scores
  candidate compute hosts by accelerator availability (GPU, NPU, FPGA, etc.)
  using the resource provider tree maintained by the Placement API.

  Nova's default weighers (RAM/CPU/Disk/PCI) do not rank hosts by
  accelerator resource classes, traits, or per-device residual capacity.
  This weigher fills that gap at the weighing stage, complementing the
  existing PCI passthrough filtering and Placement-based candidate
  generation rather than replacing them.

  ## What's included (9 commits)

  - **Core weigher** (`nova/scheduler/weights/accelerator.py`)
    - Group-based scoring: per request group, computes *slack*
      (trait-matching free capacity minus requested amount) over child
      resource providers, using RC inventory + required traits.
    - Two scoring policies:
      - `sum-fit` — total remaining capacity (worst-fit style spreading)
      - `product-fit` — product of group slacks (+ε), favoring hosts with
        balanced headroom across multiple accelerator types
    - Per-request policy override via flavor extra_spec
      `accelerator_weigher:policy` (invalid values fall back to the
      configured default).
  - **Performance**
    - Multi-layer caching: per-pass cache, TTL cache
      (`usage_cache_seconds`, default 10s), and concurrent usage fetching
      with a thread pool (`max_concurrent_usage_requests`, default 8).
    - Root RP lookup skipped by reusing `host_state.uuid` (one fewer HTTP
      round trip per host).
  - **Configuration** (`nova/conf/accelerator_weigher.py`)
    - `[accelerator_weigher]` group: `rc_pattern`, `policy`,
      `accelerator_weight_multiplier` (aggregate-overridable),
      `usage_cache_seconds`, `max_concurrent_usage_requests`, `trace`.
  - **Tests**: 31 unit tests covering scoring policies, unmet/empty groups,
    trait matching, reserved/used accounting, multiplier and aggregate
    override, UUID/pass-cache behavior, `rc_pattern` classification,
    flavor policy selection, and edge cases. All passing via stestr.
  - **CI**: tox constraints URL updated to kcloud-requirements.

 ## Usage

  ```ini
  [filter_scheduler]
  enabled_weighers = RAMWeigher,CPUWeigher,DiskWeigher,AcceleratorWeigher

  [accelerator_weigher]
  policy = sum-fit
  accelerator_weight_multiplier = 10.0

  Enabled purely through configuration — no changes to existing scheduler
  code paths; fully compatible with the other resource weighers.

  Testing

  stestr run -n nova.tests.unit.scheduler.weights.test_weights_accelerator
  Ran: 31 tests — Passed: 31, Failed: 0