### PR TITLE
ci: point auto-merge at CR_PAT_RWD and surface merge failures

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -28,7 +28,7 @@ jobs:
 
           TEAM_MEMBERS=$(curl -L \
                           -H "Accept: application/vnd.github+json" \
-                          -H "Authorization: Bearer ${{ secrets.CR_PAT }}" \
+                          -H "Authorization: Bearer ${{ secrets.CR_PAT_RWD }}" \
                           -H "X-GitHub-Api-Version: 2022-11-28" \
                           https://api.github.com/orgs/openKcloud/teams/${TEAM_NAME}/members | jq -r '.[] | .login' | tr '\n' ',')
           echo "TEAM_MEMBERS=$TEAM_MEMBERS" >> $GITHUB_ENV
@@ -56,8 +56,14 @@ jobs:
         with:
           args: "--trace"
         env:
-          GITHUB_TOKEN: "${{ secrets.CR_PAT }}"
+          GITHUB_TOKEN: "${{ secrets.CR_PAT_RWD }}"
           MERGE_LABELS: "approved,!wip,!hold"
+          # Without this the action exits 0 even when the merge was rejected,
+          # so the job shows green while the PR stays open and nothing says
+          # why. Surfacing it matters here because CR_PAT_RWD cannot merge a PR
+          # that touches .github/workflows/ unless it carries the 'workflow'
+          # scope, and that failure is otherwise only visible in the log.
+          MERGE_ERROR_FAIL: "true"
           MERGE_REMOVE_LABELS: ""
           MERGE_METHOD: "merge"
           MERGE_COMMIT_MESSAGE: "pull-request-title"


### PR DESCRIPTION
Two fixes to the `/approve` auto-merge:

- The workflow authenticated with `secrets.CR_PAT`, which does not exist in this org (only `CR_PAT_RWD` is defined, as used by the image builds). With no token the bot merge silently never happened. Point every `CR_PAT` reference at `CR_PAT_RWD`.
- Set `MERGE_ERROR_FAIL` so a rejected merge surfaces as a failed check instead of a silent green.

Note: `CR_PAT_RWD` still needs the `workflow` scope to merge PRs that touch `.github/workflows/`.